### PR TITLE
Shuffled settings balancing

### DIFF
--- a/resources/oot-randomizer/settings-randomizer.json
+++ b/resources/oot-randomizer/settings-randomizer.json
@@ -161,7 +161,7 @@
         },
         {
             "Value": "minimal",
-            "Cost": 7,
+            "Cost": 8,
             "Weight": 0.25
         }
     ],
@@ -231,27 +231,27 @@
         },
         {
             "Value": "1",
-            "Cost": 5,
-            "Weight": 0
+            "Cost": 1,
+            "Weight": 1
         },
         {
             "Value": "2",
-            "Cost": 5,
-            "Weight": 0
+            "Cost": 2,
+            "Weight": 1
         },
         {
             "Value": "3",
-            "Cost": 5,
-            "Weight": 0
+            "Cost": 3,
+            "Weight": 1
         },
         {
             "Value": "4",
-            "Cost": 5,
-            "Weight": 0
+            "Cost": 4,
+            "Weight": 1
         },
         {
             "Value": "random",
-            "Cost": 5,
+            "Cost": 4,
             "Weight": 1
         }
     ],
@@ -270,7 +270,7 @@
     "shuffle_bosskeys": [
         {
             "Value": "vanilla",
-            "Cost": 0,
+            "Cost": 1,
             "Weight": 1
         },
         {
@@ -329,7 +329,7 @@
         {
             "Value": true,
             "Cost": 3,
-            "Weight": 1
+            "Weight": 0
         },
         {
             "Value": false,
@@ -362,12 +362,12 @@
         },
         {
             "Value": "regular",
-            "Cost": 5,
+            "Cost": 8,
             "Weight": 0
         },
         {
             "Value": "random",
-            "Cost": 7,
+            "Cost": 10,
             "Weight": 0
         }
     ],
@@ -448,7 +448,7 @@
         {
             "Value": "overworld",
             "Cost": 10,
-            "Weight": 0
+            "Weight": 0.75
         },
         {
             "Value": "all",


### PR DESCRIPTION
- Minimal item pool cost increased from 7 to 8, to avoid comboing with Triforce Hunt also at 8
- Shopsanity now have all costs and weights according to the number of items they randomize, since the "random" option is weird and randomize the number within each shop
- Vanilla BK cost increased from 0 to 1 since it changed the routing around in the dungeons, mainly in Fire and Water
- Removed shuffle_medigoron_carpet_salesman is an option exclusive to Roman's branch and not in 5.2
- Increase scrub shuffle costs, even with their weight at 0 for now, since it is a really annoying option to play
- Put back Overworld tokensanity, since it is a 5.2 option and we already have Full tokensanity enabled.