### PR TITLE
Shuffled settings description files

### DIFF
--- a/resources/oot-randomizer/settings-randomizer.json
+++ b/resources/oot-randomizer/settings-randomizer.json
@@ -308,7 +308,7 @@
             "Weight": 1
         },
         {
-            "Value": "lacs_vanilla",
+            "Value": "lacs_medallions",
             "Cost": 1,
             "Weight": 0.5
         }
@@ -541,12 +541,12 @@
     "shuffle_kokiri_sword": [
         {
             "Value": true,
-            "Cost": 0,
+            "Cost": 1,
             "Weight": 1
         },
         {
             "Value": false,
-            "Cost": 1,
+            "Cost": 0,
             "Weight": 1
         }
     ]

--- a/resources/oot-randomizer/settings-randomizer.json
+++ b/resources/oot-randomizer/settings-randomizer.json
@@ -308,7 +308,7 @@
             "Weight": 1
         },
         {
-            "Value": "lacs_medallions",
+            "Value": "lacs_vanilla",
             "Cost": 1,
             "Weight": 0.5
         }
@@ -541,12 +541,12 @@
     "shuffle_kokiri_sword": [
         {
             "Value": true,
-            "Cost": 1,
+            "Cost": 0,
             "Weight": 1
         },
         {
             "Value": false,
-            "Cost": 0,
+            "Cost": 1,
             "Weight": 1
         }
     ]

--- a/resources/oot-randomizer/settings_documentation.en.json
+++ b/resources/oot-randomizer/settings_documentation.en.json
@@ -1,0 +1,422 @@
+{
+    "all_reachable": {
+        "title": "All reachable",
+        "values": [
+            {
+                "value": false,
+                "title": "false",
+                "description": "Only required items and locations to beat the game will be guaranteed reachable."
+            }
+        ]
+    },
+    "bombchus_in_logic": {
+        "title": "Bombchus in logic",
+        "values": [
+            {
+                "value": true,
+                "title": "true",
+                "description": "Bombchus are properly considered in logic."
+            }
+        ]
+    },
+    "bridge": {
+        "title": "Rainbow bridge",
+        "values": [
+            {
+                "value": "medallions",
+                "title": "medallions",
+                "description": "Bridge to Ganon's Castle appears when all 6 medaillons are obtained."
+            },
+            {
+                "value": "dungeons",
+                "title": "dungeons",
+                "description": "Bridge to Ganon's Castle appears when all 6 medaillons and all 3 Spiritual Stones are obtained."
+            },
+            {
+                "value": "open",
+                "title": "open",
+                "description": "Bridge to Ganon's Castle is always there."
+            },
+            {
+                "value": "stones",
+                "title": "stones",
+                "description": "Bridge to Ganon's Castle appears when all 3 Spiritual Stones are obtained."
+            },
+            {
+                "value": "vanilla",
+                "title": "vanilla",
+                "description": "Bridge to Ganon's Castle appears when Shadow Medaillon, Spirit Medaillon and Light Arrows are obtained."
+            }
+        ]
+    },
+    "correct_chest_sizes": {
+        "title": "Correct chest sizes",
+        "values": [
+            {
+                "value": true,
+                "title": "true",
+                "description": "Chests will be large if they contain a major item and small if they don't."
+            }
+        ]
+    },
+    "damage_multiplier": {
+        "title": "Damage multiplier",
+        "values": [
+            {
+                "value": "double",
+                "title": "double",
+                "description": "Link takes double the damage."
+            },
+            {
+                "value": "quadruple",
+                "title": "quadruple",
+                "description": "Link takes quadruple the damage."
+            },
+            {
+                "value": "half",
+                "title": "half",
+                "description": "Link takes half the damage."
+            }
+        ]
+    },
+    "entrance_shuffle": {
+        "title": "Entrance shuffle",
+        "values": [
+            {
+                "value": "dungeons",
+                "title": "dungeons",
+                "description": "Dungeon entrances are shuffled with each other, including Bottom of the Well, Ice Cavern, and Gerudo Training Grounds."
+            },
+            {
+                "value": "simple-indoors",
+                "title": "simple indoors",
+                "description": "Shuffle dungeon entrances along with simple Grotto and Interior entrances (i.e. most Houses and Great Fairies)."
+            }
+        ]
+    },
+    "hints": {
+        "title": "Hints",
+        "values": [
+            {
+                "value": "none",
+                "title": "none",
+                "description": "Gossip Stones give no hints."
+            },
+            {
+                "value": "agony",
+                "title": "Stone of Agony",
+                "description": "The Stone of Agony is required to read the Gossip Stones hints."
+            }
+        ]
+    },
+    "item_pool_value": {
+        "title": "Item pool",
+        "values": [
+            {
+                "value": "plentiful",
+                "title": "plentiful",
+                "description": "Extra major items are added."
+            },
+            {
+                "value": "scarce",
+                "title": "scarce",
+                "description": "Some excess items are removed, including health upgrades."
+            },
+            {
+                "value": "minimal",
+                "title": "minimal",
+                "description": "Most excess items are removed."
+            }
+        ]
+    },
+    "one_item_per_dungeon": {
+        "title": "Dungeons Have One Major Item",
+        "values": [
+            {
+                "value": true,
+                "title": "true",
+                "description": "Dungeons have exactly one major item except Spirit Temple which has TWO items to match vanilla distribution."
+            }
+        ]
+    },
+    "open_door_of_time": {
+        "title": "Open Door of Time",
+        "values": [
+            {
+                "value": false,
+                "title": "false",
+                "description": "The Door of Time is closed and will open if you play Song of Time in front of it."
+            }
+        ]
+    },
+    "open_forest": {
+        "title": "Kokiri Forest",
+        "values": [
+            {
+                "value": "closed_deku",
+                "title": "closed deku",
+                "description": "Mido blocks the path to the Deku Tree, requiring Kokiri Sword and Deku Shield to access the Deku Tree."
+            },
+            {
+                "value": "closed",
+                "title": "closed",
+                "description": "Completing Deku Tree is needed to get out of Kokiri Forest."
+            }
+        ]
+    },
+    "shopsanity": {
+        "title": "Shopsanity",
+        "values": [
+            {
+                "value": "1",
+                "title": "1",
+                "description": "Shops have 1 random non-shop item. They will always be on the left side."
+            },
+            {
+                "value": "2",
+                "title": "2",
+                "description": "Shops have 2 random non-shop items. They will always be on the left side."
+            },
+            {
+                "value": "3",
+                "title": "3",
+                "description": "Shops have 3 random non-shop items. They will always be on the left side."
+            },
+            {
+                "value": "4",
+                "title": "4",
+                "description": "Shops have 4 random non-shop items. They will always be on the left side."
+            },
+            {
+                "value": "random",
+                "title": "random",
+                "description": "Each shop will have a random number of non-shop items up to a maximum of 4."
+            }
+        ]
+    },
+    "shuffle_beans": {
+        "title": "Shuffle Magic Beans",
+        "values": [
+            {
+                "value": true,
+                "title": "true",
+                "description": "Adds a pack of 10 beans to the item pool, and the Magic Bean Salesman now sells a random item once at the price of 60 Rupees."
+            }
+        ]
+    },
+    "shuffle_bosskeys": {
+        "title": "Shuffle Boss Keys",
+        "values": [
+            {
+                "value": "vanilla",
+                "title": "vanilla",
+                "description": "Boss Keys will appear in their vanilla locations."
+            },
+            {
+                "value": "remove",
+                "title": "remove",
+                "description": "Boss Keys are removed and all Boss doors are unlocked."
+            },
+            {
+                "value": "keysanity",
+                "title": "anywhere",
+                "description": "Boss Keys can appear anywhere in the world."
+            }
+        ]
+    },
+    "shuffle_cows": {
+        "title": "Shuffle Cows",
+        "values": [
+            {
+                "value": true,
+                "title": "true",
+                "description": "Playing Epona's song in front of cows gives an item."
+            }
+        ]
+    },
+    "shuffle_ganon_bosskey": {
+        "title": "Shuffle Ganon Boss Key",
+        "values": [
+            {
+                "value": "lacs_vanilla",
+                "title": "vanilla Light Arrow custcene",
+                "description": "Ganon's Castle Boss Key is on the Light Arrow cutscene which unlocks when you get both Shadow and Spirit medallions."
+            }
+        ]
+    },
+    "shuffle_gerudo_card": {
+        "title": "Shuffle Gerudo card",
+        "values": [
+            {
+                "value": true,
+                "title": "true",
+                "description": "Shuffles the Gerudo Card into the item pool."
+            }
+        ]
+    },
+    "shuffle_ocarinas": {
+        "title": "Shuffle Ocarinas",
+        "values": [
+            {
+                "value": true,
+                "title": "true",
+                "description": "Shuffles the Fairy Ocarina and the Ocarina of Time into the item pool."
+            }
+        ]
+    },
+    "shuffle_scrubs": {
+        "title": "Shuffle Scrubs",
+        "values": [
+            {
+                "value": "low",
+                "title": "affordable",
+                "description": "All Deku Scrubs sells an item for 10 rupees each."
+            }
+        ]
+    },
+    "shuffle_smallkeys": {
+        "title": "Small Keys",
+        "values": [
+            {
+                "value": "vanilla",
+                "title": "vanilla",
+                "description": "Small Keys will appear in their vanilla locations."
+            },
+            {
+                "value": "remove",
+                "title": "remove",
+                "description": "Small Keys are removed and all locked doors in dungeons will be unlocked, except Boss Door."
+            },
+            {
+                "value": "keysanity",
+                "title": "anywhere",
+                "description": "Small Keys can appear anywhere in the world."
+            }
+        ]
+    },
+    "shuffle_song_items": {
+        "title": "Shuffle Songs with Items",
+        "values": [
+            {
+                "value": true,
+                "title": "true",
+                "description": "Shuffles the songs into the rest of the item pool."
+            }
+        ]
+    },
+    "shuffle_weird_egg": {
+        "title": "Shuffle Weird Egg",
+        "values": [
+            {
+                "value": true,
+                "title": "true",
+                "description": "Enabling this shuffles the Weird Egg from Malon into the pool."
+            }
+        ]
+    },
+    "starting_age": {
+        "title": "Starting age",
+        "values": [
+            {
+                "value": "adult",
+                "title": "adult",
+                "description": "Link starts as adult in Temple of Time."
+            }
+        ]
+    },
+    "tokensanity": {
+        "title": "Tokensanity",
+        "values": [
+            {
+                "value": "dungeons",
+                "title": "dungeons",
+                "description": "Token rewards from Gold Skulltulas within dungeons are shuffled into the pool."
+            },
+            {
+                "value": "overworld",
+                "title": "overworld",
+                "description": "Token rewards from Gold Skulltulas outside of dungeons are shuffled into the pool."
+            },
+            {
+                "value": "all",
+                "title": "all tokens",
+                "description": "Every Gold Skulltula token is shuffled into the pool."
+            }
+        ]
+    },
+    "zora_fountain": {
+        "title": "Zora's Fountain",
+        "values": [
+            {
+                "value": "adult",
+                "title": "open for adult",
+                "description": "King Zora is always moved in the adult era."
+            },
+            {
+                "value": "open",
+                "title": "always open",
+                "description": "King Zora starts as moved in both the child and adult eras."
+            }
+        ]
+    },
+    "gerudo_fortress": {
+        "title": "Gerudo Fortress",
+        "values": [
+            {
+                "value": "open",
+                "title": "open",
+                "description": "The bridge in Gerudo Valley is already rebuild."
+            }
+        ]
+    },
+    "triforce_hunt": {
+        "title": "Triforce Hunt",
+        "values": [
+            {
+                "value": true,
+                "title": "true",
+                "description": "Pieces of the Triforce have been scattered around the world. Find 20 of them to finish the game !"
+            }
+        ]
+    },
+    "free_scarecrow": {
+        "title": "Free Scarecrow's Song",
+        "values": [
+            {
+                "value": true,
+                "title": "true",
+                "description": "Pulling out the Ocarina near a spot at which Pierre can spawn will do so, without needing the song."
+            }
+        ]
+    },
+    "start_with_consumables": {
+        "title": "Start with Consumables",
+        "values": [
+            {
+                "value": true,
+                "title": "true",
+                "description": "Start the game with maxed out Deku Sticks and Deku Nuts."
+            }
+        ]
+    },
+    "chicken_count_random": {
+        "title": "Random Cucco Count",
+        "values": [
+            {
+                "value": true,
+                "title": "true",
+                "description": "Anju will give a reward for collecting a random number of Cuccos."
+            }
+        ]
+    },
+    "shuffle_kokiri_sword": {
+        "title": "Shuffle Kokiri Sword",
+        "values": [
+            {
+                "value": false,
+                "title": "false",
+                "description": "The Kokiri Sword is at its vanilla location."
+            }
+        ]
+    }
+}

--- a/resources/oot-randomizer/settings_documentation.fr.json
+++ b/resources/oot-randomizer/settings_documentation.fr.json
@@ -1,0 +1,422 @@
+{
+    "all_reachable": {
+        "title": "Tout accessible",
+        "values": [
+            {
+                "value": false,
+                "title": "faux",
+                "description": "Certains objets et lieux peuvent être inaccessibles."
+            }
+        ]
+    },
+    "bombchus_in_logic": {
+        "title": "Missiles teigneux en logique",
+        "values": [
+            {
+                "value": true,
+                "title": "vrai",
+                "description": "Les missiles teigneux sont pris en compte dans la logique."
+            }
+        ]
+    },
+    "bridge": {
+        "title": "Pont arc-en-ciel",
+        "values": [
+            {
+                "value": "medallions",
+                "title": "médaillons",
+                "description": "Le pont donnant accès au château de Ganon apparait une fois les 6 médaillons obtenus."
+            },
+            {
+                "value": "dungeons",
+                "title": "donjons",
+                "description": "Le pont donnant accès au château de Ganon apparait une fois les 6 médaillons et les 3 pierres ancestrales obtenus."
+            },
+            {
+                "value": "open",
+                "title": "ouvert",
+                "description": "Le pont donnant accès au château de Ganon est toujours présent."
+            },
+            {
+                "value": "stones",
+                "title": "pierres",
+                "description": "Le pont donnant accès au château de Ganon apparait une fois les 3 pierres ancestrales obtenus."
+            },
+            {
+                "value": "vanilla",
+                "title": "vanille",
+                "description": "Le pont donnant accès au château de Ganon apparait une fois que le médaillon de l'Ombre, de l'Esprit, et les Flèches de Lumière aient été obtenus."
+            }
+        ]
+    },
+    "correct_chest_sizes": {
+        "title": "Coffres à la bonne taille",
+        "values": [
+            {
+                "value": true,
+                "title": "vrai",
+                "description": "Seuls les coffres contenant un objet important sont grands."
+            }
+        ]
+    },
+    "damage_multiplier": {
+        "title": "Modification des dégâts reçus",
+        "values": [
+            {
+                "value": "double",
+                "title": "double",
+                "description": "Tout fait deux fois plus de dégâts."
+            },
+            {
+                "value": "quadruple",
+                "title": "quadruple",
+                "description": "Tout fait quatre fois plus de dégâts."
+            },
+            {
+                "value": "half",
+                "title": "moitié",
+                "description": "Tout fait moitié moins de dégâts."
+            }
+        ]
+    },
+    "entrance_shuffle": {
+        "title": "Entrées aléatoires",
+        "values": [
+            {
+                "value": "dungeons",
+                "title": "donjons",
+                "description": "Les entrées des donjons sont mélangées entre elles, y compris le Puits, la Caverne Polaire et le Gymnase Gerudo."
+            },
+            {
+                "value": "simple-indoors",
+                "title": "intérieurs simplifié",
+                "description": "Les entrées des donjons sont mélangées entre elles. Les entrées de grottes sont mélangées entre elles. La plupart des maisons ainsi que les fontaines des grandes fées sont mélangées entre elles."
+            }
+        ]
+    },
+    "hints": {
+        "title": "Indices",
+        "values": [
+            {
+                "value": "none",
+                "title": "aucun",
+                "description": "Les Pierres à potin ne donnent aucun indice."
+            },
+            {
+                "value": "agony",
+                "title": "Pierre de Souffrance",
+                "description": "Les Pierres à potin donnent des indices une fois la Pierre de Souffrance obtenue."
+            }
+        ]
+    },
+    "item_pool_value": {
+        "title": "Nombre d'objets disponibles",
+        "values": [
+            {
+                "value": "plentiful",
+                "title": "en abondance",
+                "description": "Les items importants sont disponibles en abondance."
+            },
+            {
+                "value": "scarce",
+                "title": "rare",
+                "description": "Certains objets non nécessaires sont retirés."
+            },
+            {
+                "value": "minimal",
+                "title": "unique",
+                "description": "La plupart des objets non nécessaires sont retirés."
+            }
+        ]
+    },
+    "one_item_per_dungeon": {
+        "title": "Un unique objet par donjon",
+        "values": [
+            {
+                "value": true,
+                "title": "vrai",
+                "description": "Les donjons ne peuvent contenir qu'un seul objet important, à l'exception du Temple de l'Esprit qui en contient deux."
+            }
+        ]
+    },
+    "open_door_of_time": {
+        "title": "Porte du Temps ouverte",
+        "values": [
+            {
+                "value": false,
+                "title": "faux",
+                "description": "La Porte du Temps est fermée et ne peut s'ouvrir qu'en jouant le Chant du Temps."
+            }
+        ]
+    },
+    "open_forest": {
+        "title": "Forêt Kokiri",
+        "values": [
+            {
+                "value": "closed_deku",
+                "title": "Arbre Mojo bloqué",
+                "description": "Mido bloque l'Arbre Mojo et ne laisse passer Link qu'une fois équippé d'un bouclier Mojo et de l'épée Kokiri."
+            },
+            {
+                "value": "closed",
+                "title": "fermée",
+                "description": "La sortie de la forêt Kokiri vers la plaine d'Hyrule est bloquée. Le Kokiri la bloquant ne se déplacera qu'une fois l'Arbre Mojo complété."
+            }
+        ]
+    },
+    "shopsanity": {
+        "title": "Nombre d'objets aléatoires dans les boutiques",
+        "values": [
+            {
+                "value": "1",
+                "title": "1",
+                "description": "Les boutiques vendent un objet aléatoire. Cet objet sera toujours sur le côté gauche."
+            },
+            {
+                "value": "2",
+                "title": "2",
+                "description": "Les boutiques vendent deux objets aléatoires. Ces objets seront toujours sur le côté gauche."
+            },
+            {
+                "value": "3",
+                "title": "3",
+                "description": "Les boutiques vendent trois objets aléatoires. Ces objets seront toujours sur le côté gauche."
+            },
+            {
+                "value": "4",
+                "title": "4",
+                "description": "Les boutiques vendent quatre objets aléatoires. Ces objets seront toujours sur le côté gauche."
+            },
+            {
+                "value": "random",
+                "title": "random",
+                "description": "Les boutiques vendent un nombre d'objets aléatoire, de 0 à 4. Ces objets seront toujours sur le côté gauche."
+            }
+        ]
+    },
+    "shuffle_beans": {
+        "title": "Haricots magiques",
+        "values": [
+            {
+                "value": true,
+                "title": "vrai",
+                "description": "Un pack de 10 haricots magiques est trouvable, et le vendeur de Haricots vend un unique item pour 60 rubis."
+            }
+        ]
+    },
+    "shuffle_bosskeys": {
+        "title": "Clefs de Boss",
+        "values": [
+            {
+                "value": "vanilla",
+                "title": "vanille",
+                "description": "Les clefs de Boss sont à leur emplacement d'origine."
+            },
+            {
+                "value": "remove",
+                "title": "retirées",
+                "description": "Il n'y a pas de clefs de Boss et les portes vers les Boss sont toujours ouvertes."
+            },
+            {
+                "value": "keysanity",
+                "title": "partout",
+                "description": "Les clefs de Boss peuvent être partout"
+            }
+        ]
+    },
+    "shuffle_cows": {
+        "title": "Vaches",
+        "values": [
+            {
+                "value": true,
+                "title": "vrai",
+                "description": "Jouer le Chant d'Epona à une vache donne un objet aléatoire."
+            }
+        ]
+    },
+    "shuffle_ganon_bosskey": {
+        "title": "Grande clef du Château de Ganon",
+        "values": [
+            {
+                "value": "lacs_vanilla",
+                "title": "sur la cinématique des Flèches de Lumière vanille",
+                "description": "La Grande clef du Château de Ganon est sur la cinématique des Flèches de lumière, qui se déclenche une fois les médaillons de l'Ombre et de l'Esprit obtenus."
+            }
+        ]
+    },
+    "shuffle_gerudo_card": {
+        "title": "Carte Gerudo aléatoire",
+        "values": [
+            {
+                "value": true,
+                "title": "vrai",
+                "description": "La carte Gerudo peut se trouver partout."
+            }
+        ]
+    },
+    "shuffle_ocarinas": {
+        "title": "Ocarina aléatoires",
+        "values": [
+            {
+                "value": true,
+                "title": "vrai",
+                "description": "Les deux ocarinas peuvent se trouver partout."
+            }
+        ]
+    },
+    "shuffle_scrubs": {
+        "title": "Pestes mojo",
+        "values": [
+            {
+                "value": "low",
+                "title": "abordable",
+                "description": "Toutes les Pestes Mojo vendent un item pour 10 rubis."
+            }
+        ]
+    },
+    "shuffle_smallkeys": {
+        "title": "Petites Clefs",
+        "values": [
+            {
+                "value": "vanilla",
+                "title": "vanille",
+                "description": "Les petites clefs sont à leur emplacement d'origine."
+            },
+            {
+                "value": "remove",
+                "title": "retirées",
+                "description": "Les petites clefs sont retirées, et toutes les portes des donjons sont ouvertes, excepté la porte du Boss."
+            },
+            {
+                "value": "keysanity",
+                "title": "partout",
+                "description": "Les petites clefs peuvent être partout."
+            }
+        ]
+    },
+    "shuffle_song_items": {
+        "title": "Chants aléatoires",
+        "values": [
+            {
+                "value": true,
+                "title": "vrai",
+                "description": "Les chants peuvent être partout."
+            }
+        ]
+    },
+    "shuffle_weird_egg": {
+        "title": "Oeuf curieux aléatoire",
+        "values": [
+            {
+                "value": true,
+                "title": "vrai",
+                "description": "L'oeuf curieux donné par Malon peut être partout."
+            }
+        ]
+    },
+    "starting_age": {
+        "title": "Age de départ",
+        "values": [
+            {
+                "value": "adult",
+                "title": "adulte",
+                "description": "Le jeu commence en tant que Link adulte."
+            }
+        ]
+    },
+    "tokensanity": {
+        "title": "Skulltulas d'or",
+        "values": [
+            {
+                "value": "dungeons",
+                "title": "donjons",
+                "description": "Les skulltula d'or des donjons peuvent être des objets."
+            },
+            {
+                "value": "overworld",
+                "title": "extérieur",
+                "description": "Les skulltula d'or hors des dojons peuvent être des objets."
+            },
+            {
+                "value": "all",
+                "title": "toutes",
+                "description": "Toutes les skulltula d'or peuvent être des objets."
+            }
+        ]
+    },
+    "zora_fountain": {
+        "title": "Fontaine Zora",
+        "values": [
+            {
+                "value": "adult",
+                "title": "ouverte en adulte",
+                "description": "Le roi Zora est déplacé et la fontaine Zora toujours accessible depuis le domaine Zora uniquement en adulte."
+            },
+            {
+                "value": "open",
+                "title": "toujours ouverte",
+                "description": "Le roi Zora est déplacé et la fontaine Zora toujours accessible depuis le domaine Zora."
+            }
+        ]
+    },
+    "gerudo_fortress": {
+        "title": "Forteresse Gerudo",
+        "values": [
+            {
+                "value": "open",
+                "title": "ouverte",
+                "description": "Le pont menant à la vallée Gerudo en adulte est déjà reconstruit."
+            }
+        ]
+    },
+    "triforce_hunt": {
+        "title": "Quête de la triforce",
+        "values": [
+            {
+                "value": true,
+                "title": "vrai",
+                "description": "La Triforce a été brisée par Ganon et répartie dans tout Hyrule. Trouvez 20 morceaux pour finir le jeu !"
+            }
+        ]
+    },
+    "free_scarecrow": {
+        "title": "Epouvantail toujours disponible",
+        "values": [
+            {
+                "value": true,
+                "title": "vrai",
+                "description": "Sortir l'Ocarina aux endroit où Pierre l'épouvantail peut apparaitre, le fera apparaitre sans avoir besoin de jouer le chant."
+            }
+        ]
+    },
+    "start_with_consumables": {
+        "title": "Démarrer avec batons et noix",
+        "values": [
+            {
+                "value": true,
+                "title": "vrai",
+                "description": "Le jeu commence avec 10 bâtons et 20 noix."
+            }
+        ]
+    },
+    "chicken_count_random": {
+        "title": "Nombre de cocottes aléatoire",
+        "values": [
+            {
+                "value": true,
+                "title": "vrai",
+                "description": "Le nombre de cocottes à ramener dans l'enclos d'Anju est aléatoire."
+            }
+        ]
+    },
+    "shuffle_kokiri_sword": {
+        "title": "Epée Kokiri aléatoire",
+        "values": [
+            {
+                "value": false,
+                "title": "false",
+                "description": "L'épée Kokiri est à son endroit d'origine."
+            }
+        ]
+    }
+}


### PR DESCRIPTION
- Add two files for English and French documentation for all currently shuffled settings.
- Fix 2 shuffled parameters : Ganon BK had the wrong value, and Shuffle Kokiri Sword costs were inverted.