### PR TITLE
Fix Ganon BK and Kokiri sword shuffled values

### DIFF
--- a/resources/oot-randomizer/settings-randomizer.json
+++ b/resources/oot-randomizer/settings-randomizer.json
@@ -308,7 +308,7 @@
             "Weight": 1
         },
         {
-            "Value": "lacs_medallions",
+            "Value": "lacs_vanilla",
             "Cost": 1,
             "Weight": 0.5
         }
@@ -541,12 +541,12 @@
     "shuffle_kokiri_sword": [
         {
             "Value": true,
-            "Cost": 1,
+            "Cost": 0,
             "Weight": 1
         },
         {
             "Value": false,
-            "Cost": 0,
+            "Cost": 1,
             "Weight": 1
         }
     ]


### PR DESCRIPTION
- Ganon BK had the wrong value, we intended for it to be on the vanilla LACS cutscene and not on all medaillons, which if added, should cost way more
- Shuffle Kokiri Sword in Weekly settings is at true, so it should be at 0 and false at 1, and not the opposite.