### PR TITLE
Triforce Hunt Balancing

### DIFF
--- a/resources/oot-randomizer/settings-randomizer.json
+++ b/resources/oot-randomizer/settings-randomizer.json
@@ -161,7 +161,7 @@
         },
         {
             "Value": "minimal",
-            "Cost": 8,
+            "Cost": 10,
             "Weight": 0.25
         }
     ],
@@ -493,8 +493,8 @@
     "triforce_hunt": [
         {
             "Value": true,
-            "Cost": 8,
-            "Weight": 1
+            "Cost": 6,
+            "Weight": 0.25
         },
         {
             "Value": false,


### PR DESCRIPTION
Triforce Hunt Balancing

- Reduce cost of Triforce Hunt since the mode is not really increasing the overall difficulty, and decrease the weight since it currently appears too often.
- Increase cost of Minimal item pool accordingly to avoid the horrible combo of TH + Minimal.