### PR TITLE
[PROPOSAL]: Calculate pairing max delta based on session size

### DIFF
--- a/internal/back/back_matchmaking.go
+++ b/internal/back/back_matchmaking.go
@@ -242,6 +242,19 @@ func clamp(v, min, max int) int {
 	return v
 }
 
+// getMaxDelta calculates the max distance between opponents for a given
+// session size.  This reduces the probability of smaller sessions producing
+// completely arbitrary pairings.
+func getMaxDelta(sessionSize int) int {
+	if sessionSize <= 8 {
+		return 1
+	} else if sessionSize <= 16 {
+		return 2
+	} else {
+		return 3
+	}
+}
+
 // pairPlayers randomly pairs close players together.
 // It takes a list of players sorted by their rank and matches two players
 // close enough in the list until there is no player left.
@@ -255,7 +268,7 @@ func pairPlayers(players []Player) []pair {
 	}
 
 	pairs := make([]pair, 0, len(players)/2)
-	maxDelta := 3
+	maxDelta := getMaxDelta(len(players))
 
 	for len(players) > 0 {
 		i1 := randomIndex(len(players))

--- a/internal/back/back_matchmaking_test.go
+++ b/internal/back/back_matchmaking_test.go
@@ -518,6 +518,16 @@ func TestRandomIndex(t *testing.T) {
 	}
 }
 
+func TestMaxDelta(t *testing.T) {
+	for i := 2; i <= 24; i++ {
+		maxDelta := getMaxDelta(i)
+		expectedResult := ((i + 7) / 8)
+		if getMaxDelta(i) != expectedResult {
+			t.Errorf("expected %d max delta for session size %d, got %d", expectedResult, i, maxDelta)
+		}
+	}
+}
+
 func TestPairPlayers(t *testing.T) {
 	players := make([]Player, 256)
 	for k := range players {
@@ -550,4 +560,47 @@ func TestPairPlayers(t *testing.T) {
 	for dist := 1; dist <= 32; dist++ {
 		fmt.Printf("%-3d %s\n", dist, strings.Repeat("*", distrib[dist]))
 	}
+}
+
+func TestPairingStats(t *testing.T) {
+	simulations := 1000
+	sessionSize := 8
+
+	deltas := make([]int, sessionSize/2*simulations)
+	for sim := 0; sim < simulations; sim++ {
+		players := make([]Player, sessionSize)
+		for k := range players {
+			players[k] = NewPlayer("player#" + strconv.Itoa(k))
+			players[k].ID = util.UUIDAsBlob{}
+			players[k].ID[0] = byte(k)
+		}
+		if len(players) == 0 {
+			t.Fatal("empty players")
+		}
+
+		pairs := pairPlayers(players)
+		if len(pairs) == 0 {
+			t.Fatal("empty pairs")
+		}
+		if len(pairs) != len(players)/2 {
+			t.Errorf("expected %d pairs, got %d", len(players)/2, len(pairs))
+		}
+
+		for i, v := range pairs {
+			delta := int(v.p1.ID[0]) - int(v.p2.ID[0])
+			if delta < 0 {
+				delta = -delta
+			}
+
+			deltas[len(pairs)*sim+i] = delta
+		}
+	}
+
+	sum := 0
+	for _, delta := range deltas {
+		sum += delta
+	}
+	average := float64(sum) / float64(len(deltas))
+
+	fmt.Printf("Average pairing delta: %v\n", average)
 }


### PR DESCRIPTION
This PR proposes a way to dynamically lower the variance in skill differences between pairs in smaller sessions.  This is meant to address a current weakness in the pairing algorithm where pairings in sessions of under 8 players are almost entirely independent of rank.

My proposed approach users a `maxDelta` of 1 for sessions of 8 or fewer players, a value of 2 for sessions between 9 and 16 players, and keeps the current behavior for any other sessions.

I provide a `TestPairingStats` function that can analyze the pairing quality over a number of simulated sessions.  This test is pretty redundant with `TestPairPlayers`, so let me know if you don't want it to be checked in.  Using this function to calculate average pair variance shows that the algorithm change is effective in providing closer matches for smaller sessions while still maintaining the element of chance.

```
Example pair variance for old algorithm (1000 simulations):
Players			Old			New
8			2.697			1.929
12			3.374			2.932
16			3.862			3.288
20			4.308			4.313
24*			4.632			4.679 
*same behavior
```