### PR TITLE
Changing the layout for history and session recap pages.

### DIFF
--- a/resources/web/locales/en/default.po
+++ b/resources/web/locales/en/default.po
@@ -49,7 +49,7 @@ msgstr ""
 msgid "Starts in %s"
 msgstr ""
 
-#: resources/web/templates/includes/current_races.html:34
+#: resources/web/templates/includes/current_races.html:34 resources/web/templates/layouts/sessions.html:28
 msgid "player"
 msgid_plural "players"
 msgstr[0] ""
@@ -297,27 +297,23 @@ msgstr ""
 msgid "The leaderboard is currently empty."
 msgstr ""
 
-#: resources/web/templates/layouts/one_session.html:10
+#: resources/web/templates/layouts/one_session.html:9
+msgid "Session recap"
+msgstr ""
+
+#: resources/web/templates/layouts/one_session.html:19
 msgid "Race started at %s"
 msgstr ""
 
-#: resources/web/templates/layouts/one_session.html:22
-msgid "Winner"
-msgstr ""
-
-#: resources/web/templates/layouts/one_session.html:23
-msgid "Loser"
-msgstr ""
-
-#: resources/web/templates/layouts/one_session.html:24
-msgid "Seed"
-msgstr ""
-
-#: resources/web/templates/layouts/one_session.html:35
-msgid "spoiler log"
-msgstr ""
-
 #: resources/web/templates/layouts/one_session.html:43
+msgid "Check the spoiler log"
+msgstr ""
+
+#: resources/web/templates/layouts/one_session.html:44
+msgid "Get the seed"
+msgstr ""
+
+#: resources/web/templates/layouts/one_session.html:53
 msgid "Not enough players joined this session."
 msgstr ""
 

--- a/resources/web/locales/fr/default.po
+++ b/resources/web/locales/fr/default.po
@@ -299,27 +299,23 @@ msgstr "Forfaits"
 msgid "The leaderboard is currently empty."
 msgstr "Le classement est actuellement vide."
 
-#: resources/web/templates/layouts/one_session.html:10
+#: resources/web/templates/layouts/one_session.html:9
+msgid "Session recap"
+msgstr "Récapitulatif de session"
+
+#: resources/web/templates/layouts/one_session.html:19
 msgid "Race started at %s"
 msgstr "Session du %s"
 
-#: resources/web/templates/layouts/one_session.html:22
-msgid "Winner"
-msgstr "Gagnant"
-
-#: resources/web/templates/layouts/one_session.html:23
-msgid "Loser"
-msgstr "Perdant"
-
-#: resources/web/templates/layouts/one_session.html:24
-msgid "Seed"
-msgstr "Seed"
-
-#: resources/web/templates/layouts/one_session.html:35
-msgid "spoiler log"
-msgstr "solution"
-
 #: resources/web/templates/layouts/one_session.html:43
+msgid "Check the spoiler log"
+msgstr "Voir la solution"
+
+#: resources/web/templates/layouts/one_session.html:44
+msgid "Get the seed"
+msgstr "Télécharger la seed"
+
+#: resources/web/templates/layouts/one_session.html:53
 msgid "Not enough players joined this session."
 msgstr "Il n'y avait pas assez de joueurs pour démarrer cette session."
 

--- a/resources/web/static/css/main.css
+++ b/resources/web/static/css/main.css
@@ -1,7 +1,7 @@
 /* {{{ Global */
 :root {
     --color-white: #ffffff;
-    --color-body-bg-color: #fdfdff;
+    --color-body-bg-color: #f7f7ff;
     --color-light-gray-blue: rgb(247, 250, 252);
     --color-gold: rgb(220, 172, 38);
     --color-gold-dark: rgb(191, 140, 0);
@@ -12,12 +12,14 @@
     --color-bronze: rgb(189, 126, 84);
     --color-bronze-dark: rgb(156, 82, 33);
     --color-bg-bronze: rgb(242, 225, 215);
+
+    --color-box: #fcfcff;
+    --color-forfeit: #c71f37;
 }
 
-body {
-    background-color: var(--body-bg-color);
-    font-family: "Avenir", "Ubuntu", "Noto Sans", "Segoe UI", sans-serif;
-}
+html { background-color: var(--color-body-bg-color); }
+body { font-family: "Avenir", "Ubuntu", "Noto Sans", "Segoe UI", sans-serif; }
+table.table { background-color: transparent; }
 #mainMenu .navbar-item { font-weight: bold; }
 
 /* Fix uglyness */
@@ -398,6 +400,128 @@ table.table.stats--attendance td {
     border: none;
 }
 /* }}} Stats */
+
+/* {{{ History */
+.box[class*="SessionBox"] { position: relative; }
+.SessionBox--league {
+    font-size: 2rem;
+    font-weight: lighter;
+}
+.SessionBox--datetime {
+    line-height: 1;
+    opacity: .7;
+}
+.SessionBox--players {
+    position: absolute;
+    bottom: 1.25rem;
+    right: 4.25rem;
+    font-size: 1rem;
+    font-weight: lighter;
+    line-height: 1;
+    text-align: right;
+    text-transform: uppercase;
+    color: rgb(0, 159, 253);
+}
+.SessionBox__no-match .SessionBox--players { right: 1.25rem; }
+.SessionBox--players span {
+    display: block;
+    font-size: 2rem;
+    font-weight: lighter;
+}
+.SessionBox--layer {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
+    max-width: 3rem;
+    background: rgba(0, 159, 253, 1);
+    clip-path: circle(100% at 170% 50%);
+}
+.SessionBox--layer img {
+    position: absolute;
+    right: 50%;
+    top: 50%;
+    transform: translate(50%, -50%);
+}
+.SessionBox__no-match {
+    padding: .5rem 1.25rem;
+    opacity: .4;
+}
+.SessionBox__no-match .SessionBox--league,
+.SessionBox__no-match .SessionBox--players span { font-size: 1.5rem; }
+.SessionBox__no-match .SessionBox--players { bottom: .5rem; }
+
+@media only screen and (max-width: 768px) {
+    .SessionBox--league,
+    .SessionBox--players span { font-size: 1.5rem; }
+    .SessionBox--datetime,
+    .SessionBox--players { font-size: .8rem; }
+
+    .SessionBox--players { right: 3.25rem; }
+
+    .SessionBox--layer {
+        max-width: 2rem;
+        clip-path: circle(100% at 210% 50%);
+    }
+
+    .SessionBox__no-match .SessionBox--league,
+    .SessionBox__no-match .SessionBox--players span { font-size: 1.2rem; }
+}
+/* }}} History */
+
+/*{{{ Session recap */
+div[class*="MatchList--match"] { margin-top: 0; }
+div.Match--players.columns.is-gapless { margin-bottom: 0; }
+.Match--players.columns {
+    margin: 0;
+    background: var(--color-box);
+}
+.Seed {
+    padding-top: 0;
+    padding-bottom: 0;
+}
+.Seed--number.tag {
+    margin-bottom: .5rem;
+    background-color: var(--color-box);
+}
+.Seed--number code { background: var(--color-box); }
+.Match--players .Player__loser { text-align: right; }
+.MatchList--match:not([class*="__doubleFF"]) .Match--players .Player__winner .Player--name { color: var(--color-gold-dark); }
+.MatchList--match__doubleFF .Match--players .Player--name { color: var(--color-forfeit); }
+.MatchList--match__doubleFF .Match--players .Player--time { opacity: .5; }
+
+@media only screen and (max-width: 768px){
+    div[class*="MatchList--match"]:not(:last-child) {
+        margin-bottom: 2.5rem;
+    }
+    .Match--players .Player--name { font-size: 1.1rem; }
+    .Match--players .Player--time { font-size: .8rem; }
+
+    .Link--spoiler {
+        position: absolute;
+        bottom: 0;
+        left: 50%;
+        transform: translate(-50%, 50%);
+    }
+    .Match--players.columns { border-radius: 20px; }
+}
+@media only screen and (min-width: 769px){
+    div[class*="MatchList--match"]:not(:last-child) {
+        margin-bottom: 1.5rem;
+    }
+    div[class*="MatchList--match"] {
+        overflow: hidden;
+        border: 2px solid var(--color-box);
+        border-radius: 20px;
+    }
+    .Match--players.columns {
+        border-top-right-radius: 20px;
+        border-bottom-right-radius: 20px;
+    }
+    .Match--players .Player--name { font-size: 1.5rem; }
+}
+/*}}} Session recap */
 
 /* {{{ Spoilers */
 ul.spoilers--hash {

--- a/resources/web/static/svg/arrow-right-line.svg
+++ b/resources/web/static/svg/arrow-right-line.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path fill="none" d="M0 0h24v24H0z"/><path d="M16.172 11l-5.364-5.364 1.414-1.414L20 12l-7.778 7.778-1.414-1.414L16.172 13H4v-2z" fill="rgba(255,255,255,1)"/></svg>

--- a/resources/web/templates/layouts/one_session.html
+++ b/resources/web/templates/layouts/one_session.html
@@ -6,46 +6,54 @@
 
     <div class="hero-body">
         <div class="container">
-            <h1 class="title">{{t .Locale "%s league" .Payload.League.Name}}</h1>
-            <h2 class="subtitle">{{t .Locale "Race started at %s" (.Payload.MatchSession.StartDate | datetime)}}</h2>
+            <h1 class="title">{{t .Locale "Session recap"}}</h1>
         </div>
     </div>
 </section>
 
 <section class="section">
     <div class="container">
-
-{{- if len .Payload.Matches -}}
-        <table class="table">
-            <thead>
-                <tr>
-                    <th colspan="2">{{t .Locale "Winner"}}</th>
-                    <th colspan="2">{{t .Locale "Loser"}}</th>
-                    <th colspan="2">{{t .Locale "Seed"}}</th>
-                </tr>
-            </thead>
-            <tbody>
-                {{- range $match := .Payload.Matches -}}
-                <tr>
-                    <td>{{ (index $.Payload.Players ($match.WinningEntry).PlayerID).Name }}</td>
-                    <td>{{ matchEntryStatus $.Locale $match.WinningEntry }}</td>
-                    <td>{{ (index $.Payload.Players ($match.LosingEntry).PlayerID).Name }}</td>
-                    <td>{{ matchEntryStatus $.Locale $match.LosingEntry }}</td>
-                    <td><code>{{ $match.Seed }}</code></td>
-                    <td><a href="{{uri $.Locale "matches" $match.ID.String "spoilers"}}">{{t $.Locale "spoiler log"}}</a></td>
-                </tr>
-                {{- end -}}
-            </tbody>
-        </table>
-{{else}}
-        <article class="message is-info">
-            <div class="message-body">
-                {{t .Locale "Not enough players joined this session."}}
+        <div class="columns is-multiline">
+            <div class="column">
+                <h2 class="title">{{t .Locale "%s league" .Payload.League.Name}}</h2>
+                <h3 class="subtitle">{{t .Locale "Race started at %s" (.Payload.MatchSession.StartDate | datetime)}}</h3>
             </div>
-        </article>
-{{end}}
-
+            {{- if len .Payload.Matches -}}
+            <div class="MatchList column is-full-tablet is-two-thirds-widescreen">
+                {{- range $match := .Payload.Matches -}}
+                    <div class="MatchList--match Match columns is-relative is-vcentered">
+                        <div class="Match--players columns column is-three-fifths is-mobile is-gapless">
+                            <div class="column is-half-mobile is-half is-relative">
+                                <div class="Player__winner">
+                                    <div class="Player--name">{{ (index $.Payload.Players ($match.WinningEntry).PlayerID).Name }}</div>
+                                    <div class="Player--time">{{ matchEntryStatus $.Locale $match.WinningEntry }}</div>
+                                </div>
+                            </div>
+                            <div class="column is-half-mobile is-half">
+                                <div class="Player__loser">
+                                    <div class="Player--name">{{ (index $.Payload.Players ($match.LosingEntry).PlayerID).Name }}</div>
+                                    <div class="Player--time">{{ matchEntryStatus $.Locale $match.LosingEntry }}</div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="Match--seed Seed column is-third has-text-centered is-relative">
+                            <span class="tag is-rounded Seed--number is-hidden-mobile">Seed :<code>{{ $match.Seed }}</code></span>
+                            <div class="Seed--links Link">
+                                <a href="{{uri $.Locale "matches" $match.ID.String "spoilers"}}" class="Link--spoiler button is-rounded is-small is-success">{{t $.Locale "Check the spoiler log"}}</a>
+                                <a href="#" class="Link--seed button is-rounded is-small is-outlined is-info is-light is-hidden-mobile">{{t $.Locale "Get the seed"}}</a>
+                            </div>
+                        </div>
+                    </div>
+                {{- end -}}
+            </div>
+            {{else}}
+            <article class="message is-info">
+                <div class="message-body">
+                    {{t .Locale "Not enough players joined this session."}}
+                </div>
+            </article>
+            {{end}}
+        </div>
     </div>
 </section>
-
 {{end}}

--- a/resources/web/templates/layouts/sessions.html
+++ b/resources/web/templates/layouts/sessions.html
@@ -14,27 +14,30 @@
 
     <section class="section">
         <div class="container">
-            <div class="columns is-centered">
-                <div class="column is-two-thirds">
-                    <table class="table is-fullwidth is-hoverable pastRacesTables">
-                        <thead>
-                            <th>{{t .Locale "League"}}</th>
-                            <th>{{t .Locale "Date"}}</th>
-                            <th align="right">{{t .Locale "Players"}}</th>
-                        </thead>
-                        <tbody>
-
-                            {{- range $v := .Payload.MatchSessions -}}
-                            <tr class="pastRacesTables--race">
-                                <td><a href="{{uri $.Locale "sessions" $v.ID.String}}">{{(index $.Payload.Leagues $v.LeagueID).Name}}</a></td>
-                                <td><a href="{{uri $.Locale "sessions" $v.ID.String}}">{{$v.StartDate | datetime}}</a></td>
-                                <td align="right">{{len $v.PlayerIDs}}</td>
-                            </tr>
-                            {{- end -}}
-
-                        </tbody>
-                    </table>
-                </div>
+            <div class="columns is-multiline">
+                {{- range $v := .Payload.MatchSessions -}}
+                    {{$x := len $v.PlayerIDs}}
+                    <div class="column is-full">
+                        {{if gt $x 1}}
+                        <a href="{{uri $.Locale "sessions" $v.ID.String}}" class="box is-clipped SessionBox">
+                        {{else}}
+                        <div class="box is-clipped SessionBox__no-match is-unselectable">
+                        {{end}}
+                            <div class="SessionBox--league">{{(index $.Payload.Leagues $v.LeagueID).Name}}</div>
+                            <div class="SessionBox--datetime">{{$v.StartDate | datetime}}</div>
+                            <div class="SessionBox--players"><span>{{$x}}</span>{{tn $.Locale "player" "players" (len $v.PlayerIDs)}}</div>
+                            {{if gt $x 1}}
+                            <div class="SessionBox--layer Layer">
+                                <img src="/_/svg/arrow-right-line.svg" alt="Détails" />
+                            </div>
+                            {{end}}
+                        {{if gt $x 1}}
+                        </a>
+                        {{else}}
+                        </div>
+                        {{end}}
+                    </div>
+                {{- end -}}
             </div>
         </div>
     </section>


### PR DESCRIPTION
Missing :

- URL for the "Get the seed" button
- Adding the "__doubleFF" modifier on the "MatchList--match" div. The final CSS class when there's a double forfeit should be "MatchList--match__doubleFF".