### PR TITLE
Remove Ganon BK on LACS but add Dungeon and Keysanity options

### DIFF
--- a/resources/oot-randomizer/settings-randomizer.json
+++ b/resources/oot-randomizer/settings-randomizer.json
@@ -321,10 +321,20 @@
         {
             "Value": "lacs_vanilla",
             "Cost": 1,
-            "Weight": 0.5,
+            "Weight": 0,
             "Implies": {
                 "triforce_hunt": false
             }
+        },    
+        {
+            "Value": "dungeon",
+            "Cost": 2,
+            "Weight": 1
+        },
+        {
+            "Value": "keysanity",
+            "Cost": 4,
+            "Weight": 0.5
         }
     ],
     "shuffle_gerudo_card": [

--- a/resources/oot-randomizer/settings_documentation.en.json
+++ b/resources/oot-randomizer/settings_documentation.en.json
@@ -241,6 +241,16 @@
                 "Value": "lacs_vanilla",
                 "Title": "vanilla Light Arrow custcene",
                 "Description": "Ganon's Castle Boss Key is on the Light Arrow cutscene which unlocks when you get both Shadow and Spirit medallions."
+            },
+            {
+                "Value": "dungeon",
+                "Title": "dungeon",
+                "Description": "Ganon's Castle Boss Key can only appear inside Ganon's Castle."
+            },
+            {
+                "Value": "keysanity",
+                "Title": "anywhere",
+                "Description": "Ganon's Castle Boss Key can appear anywhere in the world."
             }
         ]
     },

--- a/resources/oot-randomizer/settings_documentation.fr.json
+++ b/resources/oot-randomizer/settings_documentation.fr.json
@@ -241,6 +241,16 @@
                 "Value": "lacs_vanilla",
                 "Title": "sur la cinématique des Flèches de Lumière vanille",
                 "Description": "La Grande clef du Château de Ganon est sur la cinématique des Flèches de lumière, qui se déclenche une fois les médaillons de l'Ombre et de l'Esprit obtenus."
+            },           
+            {
+                "Value": "dungeon",
+                "Title": "donjon",
+                "Description": "La Grande clef du Château de Ganon peut être n'importe où dans le château de Ganon."
+            },
+            {
+                "Value": "keysanity",
+                "Title": "partout",
+                "Description": "La Grande clef du Château de Ganon peut être n'importe où des objets sont obtenables."
             }
         ]
     },


### PR DESCRIPTION
Ganon BK balancing

BK on LACS is hard to balance without a ton of conditions since it is useless in 6 medaillons bridge or all dungeons.
Dungeon asks to search trials for checks so it may lead to fun endings !
Keysanity just adds another item to find anywhere in the world.